### PR TITLE
[Fix #3] Implement Attribute Name Validation

### DIFF
--- a/src/Document/Resource/ResourceObject.php
+++ b/src/Document/Resource/ResourceObject.php
@@ -98,6 +98,6 @@ class ResourceObject implements \JsonSerializable
     
     private function isValidMemberName(string $name): bool
     {
-        return preg_match('/^(?=[^-_ ])[a-zA-Z0-9\x{0080}-\x{FFFF}-_ ]*(?<=[^-_ ])$/u', $name);
+        return preg_match('/^(?=[^-_ ])[a-zA-Z0-9\x{0080}-\x{FFFF}-_ ]*(?<=[^-_ ])$/u', $name) === 1;
     }
 }

--- a/src/Document/Resource/ResourceObject.php
+++ b/src/Document/Resource/ResourceObject.php
@@ -37,6 +37,9 @@ class ResourceObject implements \JsonSerializable
         if ($this->isReservedName($name)) {
             throw new \InvalidArgumentException('Can not use a reserved name');
         }
+        if (!$this->isValidMemberName($name)) {
+            throw new \OutOfBoundsException('Not a valid attribute name');
+        }
         if (isset($this->relationships[$name])) {
             throw new \LogicException("Field $name already exists in relationships");
         }
@@ -91,5 +94,10 @@ class ResourceObject implements \JsonSerializable
     private function isReservedName(string $name): bool
     {
         return in_array($name, ['id', 'type']);
+    }
+    
+    private function isValidMemberName(string $name): bool
+    {
+        return preg_match('/^(?=[^-_ ])[a-zA-Z0-9\x{0080}-\x{FFFF}-_ ]*(?<=[^-_ ])$/u', $name);
     }
 }

--- a/src/Document/Resource/ResourceObject.php
+++ b/src/Document/Resource/ResourceObject.php
@@ -95,7 +95,7 @@ class ResourceObject implements \JsonSerializable
     {
         return in_array($name, ['id', 'type']);
     }
-    
+
     private function isValidMemberName(string $name): bool
     {
         return preg_match('/^(?=[^-_ ])[a-zA-Z0-9\x{0080}-\x{FFFF}-_ ]*(?<=[^-_ ])$/u', $name) === 1;

--- a/test/Document/Resource/ResourceFieldsTest.php
+++ b/test/Document/Resource/ResourceFieldsTest.php
@@ -47,7 +47,7 @@ class ResourceFieldsTest extends TestCase
      * @param string $name
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Can not use a reserved name
-     * @dataProvider             invalidAttributeNames
+     * @dataProvider             reservedAttributeNames
      */
     public function testAttributeCanNotHaveReservedNames(string $name)
     {
@@ -59,7 +59,7 @@ class ResourceFieldsTest extends TestCase
      * @param string $name
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Can not use a reserved name
-     * @dataProvider             invalidAttributeNames
+     * @dataProvider             reservedAttributeNames
      */
     public function testRelationshipCanNotHaveReservedNames(string $name)
     {
@@ -67,11 +67,64 @@ class ResourceFieldsTest extends TestCase
         $res->setRelationship($name, Relationship::fromMeta(Meta::fromArray(['a' => 'b'])));
     }
 
-    public function invalidAttributeNames(): array
+    /**
+     * @param string $name
+     * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage Not a valid attribute name
+     * @dataProvider             invalidAttributeNames
+     */
+    public function testAttributeNameIsNotValid(string $name)
+    {
+        $res = new ResourceObject('books', 'abc');
+        $res->setAttribute($name, 1);
+    }
+    
+    /**
+     * @param string $name
+     * @dataProvider             validAttributeNames
+     */
+    public function testAttributeNameIsValid(string $name)
+    {
+        $res = new ResourceObject('books', 'abc');
+        $res->setAttribute($name, 1);
+    }
+    
+    public function reservedAttributeNames(): array
     {
         return [
             ['id'],
             ['type'],
+        ];
+    }
+    
+    public function invalidAttributeNames(): array
+    {
+        return [
+            ['_abcde'],
+            ['abcd_'],
+            ['abc$EDS'],
+            ['#abcde'],
+            ['abcde('],
+            ['b_'],
+            ['_a'],
+            ['$ab_c-d'],
+            ['-abc'],
+        ];
+    }
+    
+    public function validAttributeNames(): array
+    {
+        return [
+            ['abcd'],
+            ['abcA4C'],
+            ['abc_d3f45'],
+            ['abd_eca'],
+            ['a'],
+            ['b'],
+            ['ab'],
+            ['a-bc_de'],
+            ['abcéêçèÇ_n'],
+            ['abc 汉字 abc'],
         ];
     }
 }

--- a/test/Document/Resource/ResourceFieldsTest.php
+++ b/test/Document/Resource/ResourceFieldsTest.php
@@ -87,6 +87,7 @@ class ResourceFieldsTest extends TestCase
     {
         $res = new ResourceObject('books', 'abc');
         $res->setAttribute($name, 1);
+        $this->assertTrue(true);
     }
     
     public function reservedAttributeNames(): array

--- a/test/Document/Resource/ResourceFieldsTest.php
+++ b/test/Document/Resource/ResourceFieldsTest.php
@@ -78,7 +78,7 @@ class ResourceFieldsTest extends TestCase
         $res = new ResourceObject('books', 'abc');
         $res->setAttribute($name, 1);
     }
-    
+
     /**
      * @param string $name
      * @dataProvider             validAttributeNames
@@ -89,7 +89,7 @@ class ResourceFieldsTest extends TestCase
         $res->setAttribute($name, 1);
         $this->assertTrue(true);
     }
-    
+
     public function reservedAttributeNames(): array
     {
         return [
@@ -97,7 +97,7 @@ class ResourceFieldsTest extends TestCase
             ['type'],
         ];
     }
-    
+
     public function invalidAttributeNames(): array
     {
         return [
@@ -112,7 +112,7 @@ class ResourceFieldsTest extends TestCase
             ['-abc'],
         ];
     }
-    
+
     public function validAttributeNames(): array
     {
         return [


### PR DESCRIPTION
Fixes #3 

Explanation/example of the regex: https://regex101.com/r/KreIvw/2

- Has a positive lookahead to reject `-`, `_`, ` ` at the start
- Has a positive lookbehind to reject `-`, `_`, ` ` at the end
- Matches `a-z`, `A-Z`, `0-9`, all unicode from `0080` to `FFFF` and `-`, `_`, ` `

Wrote a couple tests, they're kinda random cases that could probably be cleaned up, but I think it should cover the majority of possibilities.

http://jsonapi.org/format/#document-member-names