### PR TITLE
MetaDocumentMember should be Attachable

### DIFF
--- a/src/Internal/MetaDocumentMember.php
+++ b/src/Internal/MetaDocumentMember.php
@@ -5,6 +5,6 @@ namespace JsonApiPhp\JsonApi\Internal;
 /**
  * @internal
  */
-interface MetaDocumentMember
+interface MetaDocumentMember extends Attachable
 {
 }


### PR DESCRIPTION
Hi, 
if I'm not mistaken, MetaDocumentMember should implement Attachable interface. 

MetaDocument [accepts](https://github.com/json-api-php/json-api/blob/master/src/MetaDocument.php#L11) MetaDocumentMember as a second (variadic) argument of its constructor. It then calls `combine()` function an pass it the MetaDocumentMembers. But the `combine()` [requires](https://github.com/json-api-php/json-api/blob/master/src/functions.php#L7) its parameters to be attachable, as it calls `attachTo()` method on them.