### PR TITLE
Fix missing data if it was passed later using attachTo method

### DIFF
--- a/examples/compound_doc.php
+++ b/examples/compound_doc.php
@@ -33,8 +33,8 @@ $comment05 = new ResourceObject(
     new Attribute('body', 'First!'),
     new SelfLink('http://example.com/comments/5'),
     new ToOne('author', new ResourceIdentifier('people', '2'))
-
 );
+
 $comment12 = new ResourceObject(
     'comments',
     '12',

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -22,6 +22,7 @@ final class Attribute implements ResourceField
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/EmptyRelationship.php
+++ b/src/EmptyRelationship.php
@@ -23,6 +23,7 @@ class EmptyRelationship implements ResourceField
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error.php
+++ b/src/Error.php
@@ -11,13 +11,10 @@ use JsonApiPhp\JsonApi\Internal\ErrorMember;
  */
 final class Error implements ErrorDocumentMember
 {
-    private $error;
-
     public function __construct(ErrorMember ...$members)
     {
-        $this->error = (object) [];
         foreach ($members as $member) {
-            $member->attachTo($this->error);
+            $member->attachTo($this);
         }
     }
 
@@ -26,6 +23,6 @@ final class Error implements ErrorDocumentMember
      */
     public function attachTo($o): void
     {
-        $o->errors[] = $this->error;
+        $o->errors[] = $this;
     }
 }

--- a/src/Error.php
+++ b/src/Error.php
@@ -11,18 +11,22 @@ use JsonApiPhp\JsonApi\Internal\ErrorMember;
  */
 final class Error implements ErrorDocumentMember
 {
+    private $error;
+
     public function __construct(ErrorMember ...$members)
     {
+        $this->error = (object) [];
         foreach ($members as $member) {
-            $member->attachTo($this);
+            $member->attachTo($this->error);
         }
     }
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {
-        $o->errors[] = $this;
+        $o->errors[] = $this->error;
     }
 }

--- a/src/Error/Code.php
+++ b/src/Error/Code.php
@@ -21,6 +21,7 @@ final class Code implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/Detail.php
+++ b/src/Error/Detail.php
@@ -21,6 +21,7 @@ final class Detail implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/Id.php
+++ b/src/Error/Id.php
@@ -21,6 +21,7 @@ final class Id implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/SourceParameter.php
+++ b/src/Error/SourceParameter.php
@@ -22,6 +22,7 @@ final class SourceParameter implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/SourcePointer.php
+++ b/src/Error/SourcePointer.php
@@ -19,6 +19,7 @@ final class SourcePointer implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/Status.php
+++ b/src/Error/Status.php
@@ -21,6 +21,7 @@ final class Status implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Error/Title.php
+++ b/src/Error/Title.php
@@ -22,6 +22,7 @@ final class Title implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ErrorDocument.php
+++ b/src/ErrorDocument.php
@@ -8,21 +8,12 @@ use JsonApiPhp\JsonApi\Internal\ErrorDocumentMember;
  * A Document containing an array of Error objects
  * @see http://jsonapi.org/format/#document-top-level
  */
-final class ErrorDocument implements \JsonSerializable
+final class ErrorDocument
 {
-    private $obj;
-
-    public function __construct(Error $error, ErrorDocumentMember ...$members)
+    public function __construct(ErrorDocumentMember ...$members)
     {
-        $this->obj = (object) [];
-        $error->attachTo($this->obj);
         foreach ($members as $member) {
-            $member->attachTo($this->obj);
+            $member->attachTo($this);
         }
-    }
-
-    public function jsonSerialize()
-    {
-        return $this->obj;
     }
 }

--- a/src/ErrorDocument.php
+++ b/src/ErrorDocument.php
@@ -8,12 +8,20 @@ use JsonApiPhp\JsonApi\Internal\ErrorDocumentMember;
  * A Document containing an array of Error objects
  * @see http://jsonapi.org/format/#document-top-level
  */
-final class ErrorDocument
+final class ErrorDocument implements \JsonSerializable
 {
+    private $obj;
+
     public function __construct(ErrorDocumentMember ...$members)
     {
+        $this->obj = (object) [];
         foreach ($members as $member) {
-            $member->attachTo($this);
+            $member->attachTo($this->obj);
         }
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->obj;
     }
 }

--- a/src/Included.php
+++ b/src/Included.php
@@ -40,6 +40,7 @@ final class Included implements Attachable
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Internal/Attachable.php
+++ b/src/Internal/Attachable.php
@@ -9,6 +9,7 @@ interface Attachable
 {
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void;
 }

--- a/src/JsonApi.php
+++ b/src/JsonApi.php
@@ -8,15 +8,13 @@ use JsonApiPhp\JsonApi\Internal\MetaDocumentMember;
 
 final class JsonApi implements MetaDocumentMember, DataDocumentMember, ErrorDocumentMember
 {
-    private $obj;
+    public $version;
 
     public function __construct(string $version = '1.0', Meta $meta = null)
     {
-        $this->obj = (object) [
-            'version' => $version,
-        ];
+        $this->version = $version;
         if ($meta) {
-            $meta->attachTo($this->obj);
+            $meta->attachTo($this);
         }
     }
 
@@ -25,6 +23,6 @@ final class JsonApi implements MetaDocumentMember, DataDocumentMember, ErrorDocu
      */
     public function attachTo($o): void
     {
-        $o->jsonapi = $this->obj;
+        $o->jsonapi = $this;
     }
 }

--- a/src/JsonApi.php
+++ b/src/JsonApi.php
@@ -8,21 +8,24 @@ use JsonApiPhp\JsonApi\Internal\MetaDocumentMember;
 
 final class JsonApi implements MetaDocumentMember, DataDocumentMember, ErrorDocumentMember
 {
-    public $version;
+    private $obj;
 
     public function __construct(string $version = '1.0', Meta $meta = null)
     {
-        $this->version = $version;
+        $this->obj = (object) [
+            'version' => $version,
+        ];
         if ($meta) {
-            $meta->attachTo($this);
+            $meta->attachTo($this->obj);
         }
     }
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {
-        $o->jsonapi = $this;
+        $o->jsonapi = $this->obj;
     }
 }

--- a/src/Link/AboutLink.php
+++ b/src/Link/AboutLink.php
@@ -12,6 +12,7 @@ final class AboutLink implements ErrorMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/FirstLink.php
+++ b/src/Link/FirstLink.php
@@ -12,6 +12,7 @@ final class FirstLink implements PaginationLink
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/LastLink.php
+++ b/src/Link/LastLink.php
@@ -12,6 +12,7 @@ final class LastLink implements PaginationLink
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/NextLink.php
+++ b/src/Link/NextLink.php
@@ -12,6 +12,7 @@ final class NextLink implements PaginationLink
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/PrevLink.php
+++ b/src/Link/PrevLink.php
@@ -12,6 +12,7 @@ final class PrevLink implements PaginationLink
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/RelatedLink.php
+++ b/src/Link/RelatedLink.php
@@ -12,6 +12,7 @@ final class RelatedLink implements RelationshipMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Link/SelfLink.php
+++ b/src/Link/SelfLink.php
@@ -14,6 +14,7 @@ final class SelfLink implements DataDocumentMember, ResourceMember, Relationship
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -26,6 +26,10 @@ final class Meta implements ErrorMember, ErrorDocumentMember, MetaDocumentMember
         $this->value = $value;
     }
 
+    /**
+     * @param object $o
+     * @internal
+     */
     public function attachTo($o): void
     {
         child($o, 'meta')->{$this->key} = $this->value;

--- a/src/NullData.php
+++ b/src/NullData.php
@@ -8,6 +8,7 @@ final class NullData implements PrimaryData
 {
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/PaginatedCollection.php
+++ b/src/PaginatedCollection.php
@@ -24,6 +24,7 @@ final class PaginatedCollection implements PrimaryData
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/Pagination.php
+++ b/src/Pagination.php
@@ -20,6 +20,7 @@ class Pagination implements ToManyMember
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ResourceCollection.php
+++ b/src/ResourceCollection.php
@@ -19,6 +19,7 @@ class ResourceCollection implements PrimaryData, Collection
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ResourceIdentifier.php
+++ b/src/ResourceIdentifier.php
@@ -35,6 +35,7 @@ final class ResourceIdentifier implements PrimaryData
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {
@@ -43,6 +44,7 @@ final class ResourceIdentifier implements PrimaryData
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachToCollection($o): void
     {

--- a/src/ResourceIdentifierCollection.php
+++ b/src/ResourceIdentifierCollection.php
@@ -19,6 +19,7 @@ class ResourceIdentifierCollection implements PrimaryData, Collection
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -61,6 +61,7 @@ final class ResourceObject implements PrimaryData
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {
@@ -77,6 +78,7 @@ final class ResourceObject implements PrimaryData
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachToCollection($o): void
     {

--- a/src/ToMany.php
+++ b/src/ToMany.php
@@ -29,6 +29,7 @@ final class ToMany implements Identifier, ResourceField
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -23,6 +23,7 @@ final class ToNull implements ResourceField
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/src/ToOne.php
+++ b/src/ToOne.php
@@ -28,6 +28,7 @@ final class ToOne implements Identifier, ResourceField
 
     /**
      * @param object $o
+     * @internal
      */
     public function attachTo($o): void
     {

--- a/test/CompoundDocumentTest.php
+++ b/test/CompoundDocumentTest.php
@@ -38,8 +38,8 @@ class CompoundDocumentTest extends BaseTestCase
             new Attribute('body', 'First!'),
             new SelfLink('http://example.com/comments/5'),
             new ToOne('author', new ResourceIdentifier('people', '2'))
-
         );
+
         $comment12 = new ResourceObject(
             'comments',
             '12',

--- a/test/benchmarks/compound10k.php
+++ b/test/benchmarks/compound10k.php
@@ -48,8 +48,8 @@ for ($count = 0; $count < 10000; $count++) {
         new Attribute('body', 'First!'),
         new SelfLink('http://example.com/comments/5'),
         new ToOne('author', new ResourceIdentifier('people', '2'))
-
     );
+
     $comment12 = new ResourceObject(
         'comments',
         '12',


### PR DESCRIPTION
Example that will work after this commit:

$error = new Error();
(new Error\Code('code')->attachTo($error);

$jsonapi = new JsonApi();
(new Meta('key', 'value'))->attachTo($jsonapi);
