### PR TITLE
array representation for ResourceObject, DataDocument, CompoundDocument

### DIFF
--- a/src/CompoundDocument.php
+++ b/src/CompoundDocument.php
@@ -2,6 +2,7 @@
 
 namespace JsonApiPhp\JsonApi;
 
+use JsonApiPhp\JsonApi\Internal\ArrayableTrait;
 use JsonApiPhp\JsonApi\Internal\DataDocumentMember;
 use JsonApiPhp\JsonApi\Internal\PrimaryData;
 
@@ -11,6 +12,8 @@ use JsonApiPhp\JsonApi\Internal\PrimaryData;
  */
 final class CompoundDocument implements \JsonSerializable
 {
+    use ArrayableTrait;
+
     private $doc;
 
     public function __construct(PrimaryData $data, Included $included, DataDocumentMember ...$members)

--- a/src/DataDocument.php
+++ b/src/DataDocument.php
@@ -2,6 +2,8 @@
 
 namespace JsonApiPhp\JsonApi;
 
+use JsonApiPhp\JsonApi\Internal\Arrayable;
+use JsonApiPhp\JsonApi\Internal\ArrayableTrait;
 use JsonApiPhp\JsonApi\Internal\DataDocumentMember;
 use JsonApiPhp\JsonApi\Internal\PrimaryData;
 
@@ -9,8 +11,10 @@ use JsonApiPhp\JsonApi\Internal\PrimaryData;
  * A Document containing the "data" member
  * @see http://jsonapi.org/format/#document-top-level
  */
-final class DataDocument implements \JsonSerializable
+final class DataDocument implements \JsonSerializable, Arrayable
 {
+    use ArrayableTrait;
+
     private $value;
 
     public function __construct(PrimaryData $data, DataDocumentMember ...$members)

--- a/src/Internal/Arrayable.php
+++ b/src/Internal/Arrayable.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace JsonApiPhp\JsonApi\Internal;
+
+/**
+ * @internal
+ */
+interface Arrayable
+{
+    /**
+     * @internal
+     */
+    public function toArray(): array;
+}

--- a/src/Internal/ArrayableTrait.php
+++ b/src/Internal/ArrayableTrait.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace JsonApiPhp\JsonApi\Internal;
+
+use function JsonApiPhp\JsonApi\oToArray;
+
+/**
+ * @internal
+ */
+trait ArrayableTrait
+{
+    public function toArray(): array
+    {
+        return oToArray($this);
+    }
+}

--- a/src/Internal/BaseResource.php
+++ b/src/Internal/BaseResource.php
@@ -3,12 +3,13 @@
 namespace JsonApiPhp\JsonApi\Internal;
 
 use function JsonApiPhp\JsonApi\isValidName;
+use function JsonApiPhp\JsonApi\oToArray;
 
 /**
  * Class BaseResource
  * @internal
  */
-class BaseResource implements Attachable
+class BaseResource implements Attachable, Arrayable
 {
     /**
      * @var string
@@ -57,5 +58,10 @@ class BaseResource implements Attachable
     public function attachTo($o): void
     {
         $o->data = $this->obj;
+    }
+
+    public function toArray(): array
+    {
+        return oToArray($this->obj);
     }
 }

--- a/src/ResourceObject.php
+++ b/src/ResourceObject.php
@@ -38,15 +38,6 @@ final class ResourceObject extends BaseResource implements PrimaryData
 
     /**
      * @param object $o
-     * @internal
-     */
-    public function attachTo($o): void
-    {
-        $o->data = $this->obj;
-    }
-
-    /**
-     * @param object $o
      */
     public function attachAsIncludedTo($o): void
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -30,3 +30,11 @@ function compositeKey(string $type, string $id): string
 {
     return "{$type}:{$id}";
 }
+
+/**
+ * @param object $o
+ */
+function oToArray($o): array
+{
+    return json_decode(json_encode($o), true);
+}

--- a/test/DataDocument/DocumentArrayRepresentationTest.php
+++ b/test/DataDocument/DocumentArrayRepresentationTest.php
@@ -1,0 +1,222 @@
+<?php declare(strict_types=1);
+
+namespace JsonApiPhp\JsonApi\Test\DataDocument;
+
+use JsonApiPhp\JsonApi\Attribute;
+use JsonApiPhp\JsonApi\CompoundDocument;
+use JsonApiPhp\JsonApi\DataDocument;
+use JsonApiPhp\JsonApi\Included;
+use JsonApiPhp\JsonApi\JsonApi;
+use JsonApiPhp\JsonApi\Link\LastLink;
+use JsonApiPhp\JsonApi\Link\NextLink;
+use JsonApiPhp\JsonApi\Link\RelatedLink;
+use JsonApiPhp\JsonApi\Link\SelfLink;
+use JsonApiPhp\JsonApi\Meta;
+use JsonApiPhp\JsonApi\PaginatedCollection;
+use JsonApiPhp\JsonApi\Pagination;
+use JsonApiPhp\JsonApi\ResourceCollection;
+use JsonApiPhp\JsonApi\ResourceIdentifier;
+use JsonApiPhp\JsonApi\ResourceIdentifierCollection;
+use JsonApiPhp\JsonApi\ResourceObject;
+use JsonApiPhp\JsonApi\Test\BaseTestCase;
+use JsonApiPhp\JsonApi\ToMany;
+use JsonApiPhp\JsonApi\ToOne;
+
+class DocumentArrayRepresentationTest extends BaseTestCase
+{
+    public function testDataDocumentArrayRepresentation(): void
+    {
+        $this->assertEquals(
+            json_decode('
+            {
+                "data": [{
+                    "type": "people",
+                    "id": "1",
+                    "attributes": {
+                        "name": "Martin Fowler"
+                    },
+                    "meta": {"apple_meta": "foo"}
+                },{
+                    "type": "people",
+                    "id": "2",
+                    "attributes": {
+                        "name": "Kent Beck"
+                    },
+                    "meta": {"apple_meta": "foo"}
+                }],
+                "links": {
+                    "self": "/books/123/relationships/authors",
+                    "related": "/books/123/authors"
+                },
+                "jsonapi": {
+                    "version": "1.0"
+                },
+                "meta": {"document_meta": "bar"}
+            }
+            ', true),
+            (new DataDocument(
+                new ResourceCollection(
+                    new ResourceObject(
+                        'people',
+                        '1',
+                        new Attribute('name', 'Martin Fowler'),
+                        new Meta('apple_meta', 'foo')
+                    ),
+                    new ResourceObject(
+                        'people',
+                        '2',
+                        new Attribute('name', 'Kent Beck'),
+                        new Meta('apple_meta', 'foo')
+                    )
+                ),
+                new SelfLink('/books/123/relationships/authors'),
+                new RelatedLink('/books/123/authors'),
+                new JsonApi(),
+                new Meta('document_meta', 'bar')
+            ))->toArray()
+        );
+    }
+
+    public function testCompoundDocumentArrayRepresentation(): void
+    {
+        $dan = new ResourceObject(
+            'people',
+            '9',
+            new Attribute('first-name', 'Dan'),
+            new Attribute('last-name', 'Gebhardt'),
+            new Attribute('twitter', 'dgeb'),
+            new SelfLink('http://example.com/people/9')
+        );
+
+        $comment05 = new ResourceObject(
+            'comments',
+            '5',
+            new Attribute('body', 'First!'),
+            new SelfLink('http://example.com/comments/5'),
+            new ToOne('author', new ResourceIdentifier('people', '2'))
+        );
+
+        $comment12 = new ResourceObject(
+            'comments',
+            '12',
+            new Attribute('body', 'I like XML better'),
+            new SelfLink('http://example.com/comments/12'),
+            new ToOne('author', $dan->identifier())
+        );
+
+        $document = new CompoundDocument(
+            new PaginatedCollection(
+                new Pagination(
+                    new NextLink('http://example.com/articles?page[offset]=2'),
+                    new LastLink('http://example.com/articles?page[offset]=10')
+                ),
+                new ResourceCollection(
+                    new ResourceObject(
+                        'articles',
+                        '1',
+                        new Attribute('title', 'JSON API paints my bikeshed!'),
+                        new SelfLink('http://example.com/articles/1'),
+                        new ToOne(
+                            'author',
+                            $dan->identifier(),
+                            new SelfLink('http://example.com/articles/1/relationships/author'),
+                            new RelatedLink('http://example.com/articles/1/author')
+                        ),
+                        new ToMany(
+                            'comments',
+                            new ResourceIdentifierCollection(
+                                $comment05->identifier(),
+                                $comment12->identifier()
+                            ),
+                            new SelfLink('http://example.com/articles/1/relationships/comments'),
+                            new RelatedLink('http://example.com/articles/1/comments')
+                        )
+                    )
+                )
+            ),
+            new Included($dan, $comment05, $comment12),
+            new SelfLink('http://example.com/articles')
+        );
+        $this->assertEquals(
+            json_decode('
+            {
+              "links": {
+                "self": "http://example.com/articles",
+                "next": "http://example.com/articles?page[offset]=2",
+                "last": "http://example.com/articles?page[offset]=10"
+              },
+              "data": [{
+                "type": "articles",
+                "id": "1",
+                "attributes": {
+                  "title": "JSON API paints my bikeshed!"
+                },
+                "links": {
+                  "self": "http://example.com/articles/1"
+                },
+                "relationships": {
+                  "author": {
+                    "links": {
+                      "self": "http://example.com/articles/1/relationships/author",
+                      "related": "http://example.com/articles/1/author"
+                    },
+                    "data": { "type": "people", "id": "9" }
+                  },
+                  "comments": {
+                    "links": {
+                      "self": "http://example.com/articles/1/relationships/comments",
+                      "related": "http://example.com/articles/1/comments"
+                    },
+                    "data": [
+                      { "type": "comments", "id": "5" },
+                      { "type": "comments", "id": "12" }
+                    ]
+                  }
+                }
+              }],
+              "included": [{
+                "type": "people",
+                "id": "9",
+                "attributes": {
+                  "first-name": "Dan",
+                  "last-name": "Gebhardt",
+                  "twitter": "dgeb"
+                },
+                "links": {
+                  "self": "http://example.com/people/9"
+                }
+              }, {
+                "type": "comments",
+                "id": "5",
+                "attributes": {
+                  "body": "First!"
+                },
+                "relationships": {
+                  "author": {
+                    "data": { "type": "people", "id": "2" }
+                  }
+                },
+                "links": {
+                  "self": "http://example.com/comments/5"
+                }
+              }, {
+                "type": "comments",
+                "id": "12",
+                "attributes": {
+                  "body": "I like XML better"
+                },
+                "relationships": {
+                  "author": {
+                    "data": { "type": "people", "id": "9" }
+                  }
+                },
+                "links": {
+                  "self": "http://example.com/comments/12"
+                }
+              }]
+            }            
+            ', true),
+            $document->toArray()
+        );
+    }
+}

--- a/test/ResourceObjectTest.php
+++ b/test/ResourceObjectTest.php
@@ -210,6 +210,48 @@ class ResourceObjectTest extends BaseTestCase
         );
     }
 
+    public function testArrayRepresentation(): void
+    {
+        $this->assertEquals(
+            json_decode('
+            {
+                "type": "apples",
+                 "id": "1",
+                 "attributes": {
+                     "title": "Rails is Omakase"
+                 },
+                 "meta": {"foo": "bar"},
+                 "links": {
+                     "self": "http://self"
+                 },
+                 "relationships": {
+                     "author": {
+                         "meta": {"foo": "bar"},
+                         "links": {
+                             "self": "http://rel/author",
+                             "related": "http://author"
+                         },
+                         "data": null
+                     }
+                 }
+            }
+            ', true),
+            (new ResourceObject(
+                'apples',
+                '1',
+                new Meta('foo', 'bar'),
+                new Attribute('title', 'Rails is Omakase'),
+                new SelfLink('http://self'),
+                new ToNull(
+                    'author',
+                    new Meta('foo', 'bar'),
+                    new SelfLink('http://rel/author'),
+                    new RelatedLink('http://author')
+                )
+            ))->toArray()
+        );
+    }
+
     public function testCanNotCreateIdAttribute()
     {
         $this->expectException(\DomainException::class);


### PR DESCRIPTION
Hi, I would like to build a request handler using the components of this library, for that I need document and resource state information.

An array representation is sufficient for ResourceObject, DataDocument, CompoundDocument.

## Added
- The toArray(); method has been implemented for ResourceObject, DataDocument, CompoundDocument objects.
- Write Unit tests 

## Additional 
 - Remove unused method \JsonApiPhp\JsonApi\ResourceObject::attachTo($o) because it identical to parent's one
