### PR TITLE
Suppress deprecated notices in PHP 8.1

### DIFF
--- a/src/CompoundDocument.php
+++ b/src/CompoundDocument.php
@@ -19,6 +19,7 @@ final class CompoundDocument implements \JsonSerializable
         $this->doc = combine($data, $included, ...$members);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->doc;

--- a/src/DataDocument.php
+++ b/src/DataDocument.php
@@ -18,6 +18,7 @@ final class DataDocument implements \JsonSerializable
         $this->value = combine($data, ...$members);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/src/ErrorDocument.php
+++ b/src/ErrorDocument.php
@@ -20,6 +20,7 @@ final class ErrorDocument implements \JsonSerializable
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->obj;

--- a/src/MetaDocument.php
+++ b/src/MetaDocument.php
@@ -13,6 +13,7 @@ final class MetaDocument implements \JsonSerializable
         $this->doc = combine($meta, ...$members);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->doc;


### PR DESCRIPTION
This will suppress deprecated notices when running on PHP 8.1 with E_ALL including E_DEPRECATED

see https://php.watch/versions/8.1/ReturnTypeWillChange

To fully fix those interface issue support for PHP 7 must be dropped.

